### PR TITLE
Adding info about the ruby gem

### DIFF
--- a/templates/pages/guide.md
+++ b/templates/pages/guide.md
@@ -78,3 +78,10 @@ This will output the compiled CSS to `stdout`, you may then redirect it to a fil
 
 To output minified CSS, simply pass the `-x` option.
 
+RubyGem
+=======
+
+Less.js is packaged into a ruby gem that includes an
+[embedded v8 engine](https://rubygems.org/gems/therubyracer). It's available on
+[rubygems](https://rubygems.org/gems/less) and provides ruby bindings to the
+compiler.


### PR DESCRIPTION
During a recent project I was very unaware that there was an updated ruby gem that runs the current less.js in an embedded v8. This is really really awesome (I just submitted a pull request to guard-less to use this version instead of the old 1.2.21 rubygem) but it took a while for me to find. I think this should be added to the lesscss website in some way so that it's easier for people to find the rubygem and informs them that it runs less.js in v8!

This is just my first draft and I'm not a writer :)
