### PR TITLE
Make border-radius example a real case usage

### DIFF
--- a/templates/pages/synopsis.md
+++ b/templates/pages/synopsis.md
@@ -28,7 +28,7 @@ h2 {
 }</code></pre></td>
   </tr>
 </table>
-		
+
 Mixins
 ------
 
@@ -42,9 +42,11 @@ as seen in the example bellow.
   <pre class="less-example"><code>// LESS
 
 .rounded-corners (@radius: 5px) {
-  border-radius: @radius;
   -webkit-border-radius: @radius;
   -moz-border-radius: @radius;
+  -ms-border-radius: @radius;
+  -o-border-radius: @radius;
+  border-radius: @radius;
 }
 
 #header {
@@ -58,14 +60,18 @@ as seen in the example bellow.
   <pre class="css-output"><code>/* Compiled CSS */
 
 #header {
-  border-radius: 5px;
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
+  -ms-border-radius: 5px;
+  -o-border-radius: 5px;
+  border-radius: 5px;
 }
 #footer {
-  border-radius: 10px;
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  -o-border-radius: 10px;
+  border-radius: 10px;
 }</code></pre>
   </td></tr>
 </table>
@@ -116,7 +122,7 @@ This makes inheritance clear and style sheets shorter.
 </code></pre>
   </td></tr>
 </table>
-		
+
 Functions & Operations
 ----------------------
 
@@ -140,7 +146,7 @@ you want.
   border-left: @the-border;
   border-right: @the-border * 2;
 }
-#footer { 
+#footer {
   color: @base-color + #003300;
   border-color: desaturate(@red, 10%);
 }
@@ -155,7 +161,7 @@ you want.
   border-left: 1px;
   border-right: 2px;
 }
-#footer { 
+#footer {
   color: #114411;
   border-color: #7d2717;
 }


### PR DESCRIPTION
Tiny update of the border-radius example.

The current example using border-radius would not be recommended in real usage. The order is not ideal and browser vendor prefix for Opera and IE are missing.

Congratulation for this brilliant library,
- Sébastien Grosjean - ZenCocoon
