### PR TITLE
Fixed type for dumpLineNumbers via media query

### DIFF
--- a/templates/pages/index.rhtml
+++ b/templates/pages/index.rhtml
@@ -5,19 +5,23 @@
       <h2>The <span>dynamic</span> stylesheet <span>language</span>.</h2>
       <h3>
         LESS extends CSS with dynamic behavior such as <span>variables</span>, <span>mixins</span>,
-        <span>operations</span> and <span>functions</span>. 
-	  </h3>
-	  <h3>
-		LESS runs on both the server-side 
-		(with <span>Node.js</span> and <span>Rhino</span>) or <span>client-side</span> (modern browsers only).
+        <span>operations</span> and <span>functions</span>.
+      </h3>
+      <h3>
+        LESS runs on both the server-side
+        (with <span>Node.js</span> and <span>Rhino</span>) or <span>client-side</span> (modern browsers only).
       </h3>
       <a id="download" href="https://raw.github.com/cloudhead/less.js/master/dist/less-1.3.3.min.js">
-        <img src="/images/download-button.png" /></a><div id="download-info"><div>version <code>1.3.3</code></div><div><a href="https://github.com/cloudhead/less.js/blob/master/CHANGELOG.md">changelog</a></div></div>
+        <img src="/images/download-button.png" />
+      </a><div id="download-info">
+      <div>version <code>1.3.3</code></div>
+      <div><a href="https://github.com/cloudhead/less.js/blob/master/CHANGELOG.md">changelog</a></div>
+    </div>
     </section>
 
     <section id="example">
       <%= markdown File.read(Toto::Paths[:pages] + '/example.md') %>
-       <%= markdown File.read(Toto::Paths[:pages] + '/usage-brief-serverside.md') %>
+      <%= markdown File.read(Toto::Paths[:pages] + '/usage-brief-serverside.md') %>
     </section>
   </div>
   <div style="clear: both"></div>
@@ -29,9 +33,10 @@
       <a href="#synopsis">overview</a>
       <a href="#usage">usage</a>
       <a href="#docs" id="guide-link">language</a>
-	  <a href="#reference" id="guide-link">function reference</a>
+      <a href="#reference" id="guide-link">function reference</a>
       <a href="https://github.com/cloudhead/less.js">source</a>
       <a href="#about">about</a>
+      <a href="http://less2css.org/" target="_blank">try it now!</a>
     </nav>
     <a href="https://twitter.com/cloudhead" class="twitter-follow-button" data-show-screen-name="false" data-width="80px" data-show-count="false" data-lang="en">Follow on twitter</a>
     <div id="dropdown">
@@ -67,14 +72,14 @@
 <section id="docs" class="page page-light">
   <h1>The Language</h1>
   <div class="content">
-      <%= markdown File.read(Toto::Paths[:pages] + '/doc.md') %>
+    <%= markdown File.read(Toto::Paths[:pages] + '/doc.md') %>
   </div>
 </section>
 
 <section id="reference" class="page page-light">
   <h1>Function Reference</h1>
   <div class="content">
-      <%= markdown File.read(Toto::Paths[:pages] + '/reference.md') %>
+    <%= markdown File.read(Toto::Paths[:pages] + '/reference.md') %>
   </div>
 </section>
 
@@ -82,13 +87,13 @@
   <div class="content">
     <h1>In Other Languages</h1>
     <ul>
-        <li>Russian: <a href="http://lesscss.ru">http://lesscss.ru</a></li>
-        <li>Chinese: <a href="http://lesscss.net">http://lesscss.net</a></li>
-        <li>Japanese: <a href="http://less-ja.studiomohawk.com/">http://less-ja.studiomohawk.com/</a></li>
-        <li>Polish: <a href="http://ciembor.github.com/lesscss.org/">http://ciembor.github.com/lesscss.org/</a></li>
-        <li>Indonesian: <a href="http://bertzzie.com/post/7/dokumentasi-less-bahasa-indonesia">http://bertzzie.com/post/7/dokumentasi-less-bahasa-indonesia</a></li>
-		<li>Belorussian: (Out of date) <a href="http://www.designcontest.com/show/lesscss-be">http://www.designcontest.com/show/lesscss-be</a></li>
-        <li>Portugese: (Out of date) <a href="http://lesscss.loopinfinito.com.br/">http://lesscss.loopinfinito.com.br/</a></li>
+      <li>Russian: <a href="http://lesscss.ru">http://lesscss.ru</a></li>
+      <li>Chinese: <a href="http://lesscss.net">http://lesscss.net</a></li>
+      <li>Japanese: <a href="http://less-ja.studiomohawk.com/">http://less-ja.studiomohawk.com/</a></li>
+      <li>Polish: <a href="http://ciembor.github.com/lesscss.org/">http://ciembor.github.com/lesscss.org/</a></li>
+      <li>Indonesian: <a href="http://bertzzie.com/post/7/dokumentasi-less-bahasa-indonesia">http://bertzzie.com/post/7/dokumentasi-less-bahasa-indonesia</a></li>
+    <li>Belorussian: (Out of date) <a href="http://www.designcontest.com/show/lesscss-be">http://www.designcontest.com/show/lesscss-be</a></li>
+      <li>Portugese: (Out of date) <a href="http://lesscss.loopinfinito.com.br/">http://lesscss.loopinfinito.com.br/</a></li>
     </ul>
   </div>
 </section>

--- a/templates/pages/usage.md
+++ b/templates/pages/usage.md
@@ -1,7 +1,7 @@
 Client-side usage
 =================
 
-Client-side is the easiest way to get started and good for developing your less. For production and especially 
+Client-side is the easiest way to get started and good for developing your less. For production and especially
 if performance is important, we recommend pre-compiling using node or one of the many third party tools.
 
 Link your `.less` stylesheets with the `rel` set to "`stylesheet/less`":
@@ -20,15 +20,15 @@ You can set options by setting things on a global less object before the script.
 	    less = {
 			env: "development", // or "production"
 			async: false,		// load imports async
-			fileAsync: false,   // load imports async when in a page under 
+			fileAsync: false,   // load imports async when in a page under
 								// a file protocol
 			poll: 1000,			// when in watch mode, time in ms between polls
 			functions: {},		// user functions, keyed by name
-			dumpLineNumbers: "comments", // or "mediaQuery" or "all"
+			dumpLineNumbers: "comments", // or "mediaquery" or "all"
 			relativeUrls: false,// whether to adjust url's to be relative
 								// if false, url's are already relative to the
 								// entry less file
-			rootpath: ":/a.com/"// a path to add on to the start of every url 
+			rootpath: ":/a.com/"// a path to add on to the start of every url
 								//resource
 		};
 	</script>
@@ -49,7 +49,7 @@ It is possible to output rules in your css which allow tools to locate the sourc
 
 Either specify the option `dumpLineNumbers` as above or add `!dumpLineNumbers:mediaQuery` to the url.
 
-You can use the "comments" option with [FireLESS](https://addons.mozilla.org/en-us/firefox/addon/fireless/) and 
+You can use the "comments" option with [FireLESS](https://addons.mozilla.org/en-us/firefox/addon/fireless/) and
 the "mediaQuery" option with FireBug/Chrome dev tools (it is identical to the SCSS media query debugging format).
 
 Server-side usage
@@ -61,7 +61,7 @@ Installation
 The easiest way to install LESS on the server, is via [npm](http://github.com/isaacs/npm), the node package manager, as so:
 
     $ npm install -g less
-	
+
 Command-line usage
 ------------------
 


### PR DESCRIPTION
I am finishing up writing an options panel for less2css.org and noticed a typo on the lesscss.org usage docs.

It currently states possible options for `dumpLineNumbers` as "comments", "mediaQuery", and "all"; however, the source accepts only all-lowercase, not camel-case for the media query option.

I figured it would be easiest to just update the docs rather that refactor the code (e.g. -  `switch(env.dumpLineNumbers.toLowerCase())` - which would be required to maintain compatibility with previous versions).
