### PR TITLE
Corrected result of hardlight(#ff6600, #cccccc);

### DIFF
--- a/templates/pages/reference.md
+++ b/templates/pages/reference.md
@@ -1449,7 +1449,7 @@ Example:
 
 ![Color 1](http://placehold.it/100x40/ff6600/ffffff&text=ff6600)
 ![Color 2](http://placehold.it/100x40/cccccc/000000&text=cccccc)
-![Color 3](http://placehold.it/100x40/ff2900/ffffff&text=ff2900)
+![Color 3](http://placehold.it/100x40/ffc299/ffffff&text=ffc299)
 
     hardlight(#ff6600, #ffffff);
 


### PR DESCRIPTION
Verified the result with lessc 1.3.3:

```
$ lessc -
a {
  color: hardlight(#ff6600, #cccccc);
}
^D
a {
  color: #ffc299;
}
```
