### PR TITLE
correct order for css3 properties with vendor prefix

### DIFF
--- a/public/css/all.css
+++ b/public/css/all.css
@@ -149,9 +149,9 @@ strong { font-weight: bold; }
   border-bottom: solid 1px #dddddd;
   font-size: 16px;
   line-height: 20px;
-  box-shadow: 0 -4px 6px #dddddd;
   -moz-box-shadow: 0 -4px 6px #dddddd;
   -webkit-box-shadow: 0 -4px 6px #dddddd;
+  box-shadow: 0 -4px 6px #dddddd;
 }
 #content .code_example span { color: #ffefb4; }
 #content .code_example .less_example {
@@ -213,9 +213,9 @@ strong { font-weight: bold; }
   width: 140px;
   padding: 5px 5px;
   margin-bottom: 10px;
-  box-shadow: 0 -1px 3px #cccccc;
   -moz-box-shadow: 0 -1px 3px #cccccc;
   -webkit-box-shadow: 0 -1px 3px #cccccc;
+  box-shadow: 0 -1px 3px #cccccc;
 }
 #follow a { color: #ffffff; }
 #buzz {
@@ -291,9 +291,9 @@ strong { font-weight: bold; }
   margin-bottom: 20px;
   background-color: #f5f5f5;
   font-size: 13px;
-  box-shadow: 0 0 5px #cccccc;
   -moz-box-shadow: 0 0 5px #cccccc;
   -webkit-box-shadow: 0 0 5px #cccccc;
+  box-shadow: 0 0 5px #cccccc;
 }
 #latest h3 {
   font-size: 18px;

--- a/public/less/main.less
+++ b/public/less/main.less
@@ -12,36 +12,36 @@
 
 .box-shadow (@x, @y, @blur, @alpha) {
   @value: @x @y @blur rgba(0, 0, 0, @alpha);
-  box-shadow:         @value;
   -moz-box-shadow:    @value;
   -webkit-box-shadow: @value;
+  box-shadow:         @value;
 }
 .border-radius (@radius) {
-  border-radius: @radius;
   -moz-border-radius: @radius;
   -webkit-border-radius: @radius;
+  border-radius: @radius;
 }
 
 .border-radius (@radius, bottom) {
-  border-top-right-radius: 0;
-  border-top-left-radius: 0;
   -moz-border-top-right-radius: 0;
   -moz-border-top-left-radius: 0;
   -webkit-border-top-left-radius: 0;
   -webkit-border-top-right-radius: 0;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
 }
 .border-radius (@radius, right) {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
   -moz-border-bottom-left-radius: 0;
   -moz-border-top-left-radius: 0;
   -webkit-border-bottom-left-radius: 0;
   -webkit-border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
 }
 .box-shadow-inset (@x, @y, @blur, @color) {
-  box-shadow: @x @y @blur @color inset;
   -moz-box-shadow: @x @y @blur @color inset;
   -webkit-box-shadow: @x @y @blur @color inset;
+  box-shadow: @x @y @blur @color inset;
 }
 .code () {
   font-family: 'Bitstream Vera Sans Mono',
@@ -52,10 +52,10 @@
 }
 .wrap () {
   text-wrap: wrap;
-  white-space: pre-wrap;       /* css-3 */
   white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
   white-space: -pre-wrap;      /* Opera 4-6 */
   white-space: -o-pre-wrap;    /* Opera 7 */
+  white-space: pre-wrap;       /* css-3 */
   word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 

--- a/templates/pages/doc.md
+++ b/templates/pages/doc.md
@@ -121,9 +121,9 @@ Parametric Mixins
 LESS has a special type of ruleset which can be mixed in like classes, but accepts parameters. Here's the canonical example:
 
     .border-radius (@radius) {
-      border-radius: @radius;
       -moz-border-radius: @radius;
       -webkit-border-radius: @radius;
+      border-radius: @radius;
     }
 
 And here's how we can mix it into various rulesets:
@@ -138,9 +138,9 @@ And here's how we can mix it into various rulesets:
 Parametric mixins can also have default values for their parameters:
 
     .border-radius (@radius: 5px) {
-      border-radius: @radius;
       -moz-border-radius: @radius;
       -webkit-border-radius: @radius;
+      border-radius: @radius;
     }
 
 We can invoke it like this now:
@@ -156,8 +156,8 @@ but want to include its properties in other rulesets:
 
     .wrap () {
       text-wrap: wrap;
-      white-space: pre-wrap;
       white-space: -moz-pre-wrap;
+      white-space: pre-wrap;
       word-wrap: break-word;
     }
 
@@ -167,8 +167,8 @@ Which would output:
 
     pre {
       text-wrap: wrap;
-      white-space: pre-wrap;
       white-space: -moz-pre-wrap;
+      white-space: pre-wrap;
       word-wrap: break-word;
     }
 
@@ -215,17 +215,17 @@ compiles into:
 if you don't want to deal with individual parameters:
 
     .box-shadow (@x: 0; @y: 0; @blur: 1px; @color: #000) {
-      box-shadow: @arguments;
       -moz-box-shadow: @arguments;
       -webkit-box-shadow: @arguments;
+      box-shadow: @arguments;
     }
     .box-shadow(2px; 5px);
 
 Which results in:
 
-      box-shadow: 2px 5px 1px #000;
       -moz-box-shadow: 2px 5px 1px #000;
       -webkit-box-shadow: 2px 5px 1px #000;
+      box-shadow: 2px 5px 1px #000;
 
 ### Advanced arguments and the `@rest` variable
 

--- a/templates/pages/example.md
+++ b/templates/pages/example.md
@@ -3,9 +3,9 @@ Write some LESS:
     @base: #f938ab;
 
     .box-shadow(@style, @c) when (iscolor(@c)) {
-      box-shadow:         @style @c;
       -webkit-box-shadow: @style @c;
       -moz-box-shadow:    @style @c;
+      box-shadow:         @style @c;
     }
     .box-shadow(@style, @alpha: 50%) when (isnumber(@alpha)) {
       .box-shadow(@style, rgba(0, 0, 0, @alpha));


### PR DESCRIPTION
If you list the vendor prefix after the actual property, the vendor prefix will override and be the property that renders. This will result in a different appearance in modern browsers.

details: http://css-tricks.com/ordering-css3-properties/
